### PR TITLE
Fix: skip the data if there is no row while migrating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ga_extractor/__pycache__/

--- a/ga_extractor/extractor.py
+++ b/ga_extractor/extractor.py
@@ -248,8 +248,9 @@ def __migrate_extract(credentials, table_id, date_ranges):
         with build('analyticsreporting', 'v4', credentials=credentials) as service:
             body["reportRequests"][0]["dateRanges"] = [r]
             response = service.reports().batchGet(body=body).execute()
-
-            rows[r["startDate"]] = response["reports"][0]["data"]["rows"]
+            num_rows = response["reports"][0]["data"]["totals"][0]["values"]
+            if len(list(filter(lambda x: x != '0', num_rows))):
+                rows[r["startDate"]] = response["reports"][0]["data"]["rows"]
 
     return rows
 


### PR DESCRIPTION
@MartinHeinz First of all, thank you so much for this awesome tool to take backup as UA is going down.

1. This PR resolves this issue #1. It will skip the data is there is no data returned for the day.
2. Added .gitignore file to ignore python cache files.